### PR TITLE
Fix linking error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,8 @@ include_directories(${Qt5Quick_INCLUDE_DIRS})
 find_package(Qt5QuickTest REQUIRED)
 include_directories(${Qt5QuickTest_INCLUDE_DIRS})
 
+find_package(Intl REQUIRED)
+
 pkg_check_modules(GLIB2 REQUIRED glib-2.0)
 include_directories(${GLIB2_INCLUDE_DIRS})
 

--- a/src/libusermetricsinput/CMakeLists.txt
+++ b/src/libusermetricsinput/CMakeLists.txt
@@ -71,6 +71,7 @@ target_link_libraries(
 	usermetricsinput
 	${USERMETRICS_INPUT_DEPENDENCIES}
 	usermetricscommon
+	${Intl_LIBRARIES}
 )
 
 set_target_properties(
@@ -141,5 +142,6 @@ target_link_libraries(
 	usermetricsinput-increment
 	Qt5::Core
 	usermetricsinput
+	${Intl_LIBRARIES}
 )
 

--- a/tests/testutils/main.cpp
+++ b/tests/testutils/main.cpp
@@ -19,6 +19,7 @@
 #include <QtCore/QCoreApplication>
 #include <cstdlib>
 #include <gtest/gtest.h>
+#include <libintl.h>
 
 int main(int argc, char **argv) {
 	setenv("LANG", "C.UTF-8", true);

--- a/tests/unit/libusermetricsoutput/CMakeLists.txt
+++ b/tests/unit/libusermetricsoutput/CMakeLists.txt
@@ -23,6 +23,7 @@ target_link_libraries(
 	${GSETTINGS_QT_LIBRARIES}
 	${GTEST_LIBRARIES}
 	${GMOCK_LIBRARIES}
+	${Intl_LIBRARIES}
 )
 
 add_test(


### PR DESCRIPTION
... and add a missing include

For reference, this is the error this fixes:
```
[100%] Linking CXX executable usermetricsoutput-unit-tests
/usr/lib/gcc/x86_64-alpine-linux-musl/8.2.0/../../../../x86_64-alpine-linux-musl/bin/ld: ../../../src/libusermetricsoutput/libusermetricsoutput.a(GSettingsColorThemeProvider.cpp.o): undefined reference to symbol 'libintl_dgettext'
/usr/lib/gcc/x86_64-alpine-linux-musl/8.2.0/../../../../x86_64-alpine-linux-musl/bin/ld: //usr/lib/libintl.so.8: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```